### PR TITLE
Change pyusb version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,4 @@ setup(name             = 'pyMiniCircuits',
       license          = 'BSD',
       packages         = ['minicircuits'],
       scripts          = ['mini-attenuator'],
-      install_requires = ['pyusb>=1.0', 'blinkstick'])
+      install_requires = ['pyusb>=1.0.rc1', 'blinkstick'])


### PR DESCRIPTION
I changed the pyusb version specifier to allow for the latest installable verison from pip, 1.0.0.rc1. 

Version compatible:

```
root@3faee96ee964:/tmp/pyminicircuits# python -c 'import usb; print usb.version_info'
(1, 0, 0, 'rc1')
root@3faee96ee964:/tmp/pyminicircuits# sudo python mini-attenuator get
30.0
root@3faee96ee964:/tmp/pyminicircuits# 
```

Version specifier transcripts:

```
root@5b6e9dfd2f4d:/py# pip install pyusb==1.0.0rc1                                                                                                                                                                
Downloading/unpacking pyusb==1.0.0rc1
  Downloading pyusb-1.0.0rc1.tar.gz (53Kb): 53Kb downloaded
  Running setup.py egg_info for package pyusb

Installing collected packages: pyusb
  Running setup.py install for pyusb

Successfully installed pyusb
Cleaning up...
root@5b6e9dfd2f4d:/py# pip install .
Unpacking /py
  Running setup.py egg_info for package from file:///py

Requirement already satisfied (use --upgrade to upgrade): pyusb>=1.0.rc1 in /usr/local/lib/python2.7/dist-packages (from pyMiniCircuits==0.1)
Downloading/unpacking blinkstick (from pyMiniCircuits==0.1)
  Downloading BlinkStick-1.1.8.tar.gz
  Running setup.py egg_info for package blinkstick

Installing collected packages: blinkstick, pyMiniCircuits
  Running setup.py install for blinkstick
    changing mode of build/scripts-2.7/blinkstick from 644 to 755

    changing mode of /usr/local/bin/blinkstick to 755
  Running setup.py install for pyMiniCircuits
    changing mode of build/scripts-2.7/mini-attenuator from 644 to 755

    changing mode of /usr/local/bin/mini-attenuator to 755
Successfully installed blinkstick pyMiniCircuits
Cleaning up...
root@5b6e9dfd2f4d:/py# 
```
